### PR TITLE
Add configurable support for both keypress states

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ Example devices: Mirabox N3 rev. 2 (PID 1003), Mirabox N4, Akp03 rev. 2 (PIDs st
 
 In some cases specific devices are not covered just by matching by protocol version
 
+### `with_supports_both_keypress_states(supports: bool)`
+
+Allows to disable handling both "Up" and "Down" states for key presses
+
+Default: true if protocol_version > 2
+
 ### `with_supports_both_encoder_states(supports: bool)`
 
 Allows to disable handling both "Up" and "Down" states for encoder presses

--- a/src/device.rs
+++ b/src/device.rs
@@ -187,6 +187,8 @@ pub struct Device {
     pub firmware_version: Option<String>,
     /// Protocol version
     protocol_version: usize,
+    /// Whether the device is capable of reporting ButtonUp
+    supports_both_keypress_states: bool,
     /// Whether the device is capable of reporting EncoderUp
     supports_both_encoder_states: bool,
     /// Number of keys
@@ -266,6 +268,7 @@ impl Device {
             serial_number,
             firmware_version,
             protocol_version: override_protocol_version,
+            supports_both_keypress_states: override_protocol_version > 2,
             supports_both_encoder_states: override_protocol_version > 2,
             key_count,
             encoder_count,
@@ -288,6 +291,11 @@ impl Device {
         };
 
         Device::read_firmware_version_from_raw_device(&device).await
+    }
+
+    pub fn with_supports_both_keypress_states(mut self, supports: bool) -> Self {
+        self.supports_both_keypress_states = supports;
+        self
     }
 
     pub fn with_supports_both_encoder_states(mut self, supports: bool) -> Self {
@@ -587,6 +595,7 @@ impl Device {
         #[allow(clippy::arc_with_non_send_sync)]
         Arc::new(DeviceStateReader {
             protocol_version: self.protocol_version,
+            supports_both_keypress_states: self.supports_both_keypress_states,
             supports_both_encoder_states: self.supports_both_encoder_states,
             reader: self.reader.clone(),
             states: Mutex::new(DeviceState {

--- a/src/state.rs
+++ b/src/state.rs
@@ -35,6 +35,7 @@ pub struct DeviceState {
 /// You can only have one active reader per device at a time
 pub struct DeviceStateReader {
     pub protocol_version: usize,
+    pub supports_both_keypress_states: bool,
     pub supports_both_encoder_states: bool,
     pub reader: Arc<Mutex<DeviceReader>>,
     pub states: Mutex<DeviceState>,
@@ -42,11 +43,6 @@ pub struct DeviceStateReader {
 }
 
 impl DeviceStateReader {
-    /// Checks if protocol version supports both keypress states
-    pub fn supports_both_states(&self) -> bool {
-        self.protocol_version > 2
-    }
-
     /// Reads data from device
     pub async fn raw_read_data(&self, length: usize) -> Result<Vec<u8>, MirajazzError> {
         let mut buf = vec![0u8; length];
@@ -109,7 +105,7 @@ impl DeviceStateReader {
             return Ok(DeviceInput::NoData);
         }
 
-        let state = if self.supports_both_states() {
+        let state = if self.supports_both_keypress_states {
             data[10]
         } else {
             0x1u8
@@ -137,7 +133,7 @@ impl DeviceStateReader {
                 for (index, (their, mine)) in
                     zip(buttons.iter(), my_states.buttons.iter()).enumerate()
                 {
-                    if !self.supports_both_states() {
+                    if !self.supports_both_keypress_states {
                         if *their {
                             updates.push(DeviceStateUpdate::ButtonDown(index as u8));
                             updates.push(DeviceStateUpdate::ButtonUp(index as u8));


### PR DESCRIPTION
This PR adds explicit support for configuring whether a device reports both `ButtonDown` and `ButtonUp` events independently from the protocol version.

- Added `supports_both_keypress_states` to Device
- Added `with_supports_both_keypress_states(bool)` builder method
- Replaced `supports_both_states()` protocol-version check with the new dedicated flag
- Added documentation for `with_supports_both_keypress_states`