### PR TITLE
Switch to the Lanczos3 filter when resizing images

### DIFF
--- a/src/images.rs
+++ b/src/images.rs
@@ -13,7 +13,7 @@ fn convert_image_with_format_impl(
     // Ensuring size of the image
     let (ws, hs) = image_format.size;
 
-    let image = image.resize_exact(ws as u32, hs as u32, FilterType::Nearest);
+    let image = image.resize_exact(ws as u32, hs as u32, FilterType::Lanczos3);
 
     // Applying rotation
     let image = match image_format.rotation {


### PR DESCRIPTION
Recent decks like the Fifine Ampligame D6 (the one I own) and Mirabox 293V3 use a better screen and have 112x112px keys. At this size the `Nearest` filter produces very aliased images. `Lanczos3` is the most popular filter when scaling down an image, delivering the best quality. I think it could improve rendering even on older stream decks.

**Nearest** - Pretty blocky

<img width="1658" height="1080" alt="nearest-filter" src="https://github.com/user-attachments/assets/d58c28b9-05b1-4987-b473-f3b26332a74f" />

**Lanczos3** - Pretty smooth (just like with the official app on Windows)

<img width="1658" height="1080" alt="lanczos3-filter" src="https://github.com/user-attachments/assets/6532bd1e-3a06-4979-93ac-5ab27476a3cd" />

A comparison of the different filters can be seen in [this documentation](https://docs.rs/image/latest/image/imageops/enum.FilterType.html), with a little benchmark. So it's not an issue on modern computers. It might slightly increase CPU usage with some plugins that update the image a lot, like monitoring ones, but that's it.